### PR TITLE
linux compatibility

### DIFF
--- a/Gutenberg2Epub_cli.py
+++ b/Gutenberg2Epub_cli.py
@@ -12,7 +12,7 @@ def validate_url(url):
 
 def run_gscraper(url, output_directory):
     try:
-        gscraper_script_path = "gscraper.py"  # Assuming gscraper.py is in the same directory
+        gscraper_script_path = "gScraper.py"  # Assuming gscraper.py is in the same directory
 
         result = subprocess.run(["python", gscraper_script_path, url, "-d", output_directory], capture_output=True, text=True, check=True)
 

--- a/converter.py
+++ b/converter.py
@@ -348,7 +348,7 @@ def convert_to_epub(html_directory):
 
                 
     #delete the /temp from html_directory
-    epub_directory = html_directory.replace('\\temp', '')
+    epub_directory = os.path.dirname(html_directory)
     # Create an EPUB file
     epub_file = os.path.join(epub_directory, book_title + '.epub')
     epub.write_epub(epub_file, book, {})

--- a/gui.py
+++ b/gui.py
@@ -149,7 +149,7 @@ class MyFrame2(wx.Frame):
             if exe == True:
                 result = subprocess.run([gscraper_script_path, url, "-d", output_directory], capture_output=True, text=True)
             elif exe == False:      
-                result = subprocess.run(["python", "gscraper.py", url, "-d", output_directory], capture_output=True, text=True)
+                result = subprocess.run(["python", "gScraper.py", url, "-d", output_directory], capture_output=True, text=True)
 
             output_directory = result.stdout.strip()
             print(output_directory)


### PR DESCRIPTION
Mit Linux starte ich das Programm direkt als Pythonskript, in dem Fall verstecken sich zwei Tippfehler.  

Die Ersetzung `html_directory.replace('\\temp', '')` hat unter Linux nicht das gewünschte Ergebnis, da für die Ordnerstruktur hier ein Slash statt Backslash verwendet wird. Dadurch wird am Ende jede Datei - inklusive dem erzeugten Epub - gelöscht.

Vielen Dank fürs Teilen dieses Tools, das war gerade sehr nützlich :-)